### PR TITLE
fix: support autogroup in nodeAttrs

### DIFF
--- a/internal/domain/acl.go
+++ b/internal/domain/acl.go
@@ -164,6 +164,10 @@ func (a ACLPolicy) NodeCapabilities(m *Machine) []tailcfg.NodeCapability {
 					}
 				}
 			}
+
+			if (alias == AutoGroupMember || alias == AutoGroupMembers || alias == AutoGroupSelf) && !m.HasTags() {
+				return true
+			}
 		}
 
 		return false


### PR DESCRIPTION
This PR fixes [`domain.ACLPolicy#NodeCapabilities()`](https://github.com/jsiebens/ionscale/blob/d44832ea782ec21ed95aba9b2702f182ccf1946b/internal/domain/acl.go#L143) routine to also support `autogroup:member` and `autogroup:self` as targets