### PR TITLE
enable stacktrace when debugging

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -353,6 +353,10 @@ func setupLogging(config config.Logging) (*zap.Logger, error) {
 	pc.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 	pc.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 
+	if level.Level() == zap.DebugLevel {
+		pc.DisableStacktrace = false
+	}
+
 	if config.File != "" {
 		pc.OutputPaths = []string{config.File}
 	}


### PR DESCRIPTION
Frustrating to debug/develop anything if the stacktrace is disabled. This enables it ONLY if the debug level is DEBUG, which seems fair.